### PR TITLE
Use a specific version of the CentOS base image (centos-openjdk:8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM parrotstream/centos-openjdk
+FROM parrotstream/centos-openjdk:8
 
 USER root
 


### PR DESCRIPTION
The latest version, as of now, uses OpenJDK 11 that makes  `start-impala.sh ` script unable to start hadoop namenode.
The following exception shown on the console is little unintutive, but causes due to the Java version higher than 8.
```
#  /etc/init.d/hadoop-hdfs-namenode init                                                                                                                      
19/01/05 13:54:52 ERROR namenode.NameNode: Failed to start namenode.                                                                                                             
java.lang.ExceptionInInitializerError                                                                                                                                               
        at org.apache.hadoop.util.StringUtils.<clinit>(StringUtils.java:79)                                                                                                        
        at org.apache.hadoop.hdfs.server.namenode.NameNode.main(NameNode.java:1614)                                                                                                 
Caused by: java.lang.StringIndexOutOfBoundsException: begin 0, end 3, length 2                                                                                                     
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3319)                                                                                                           
        at java.base/java.lang.String.substring(String.java:1874)                                                                                                                       
        at org.apache.hadoop.util.Shell.<clinit>(Shell.java:50)                                                                                                                      
        ... 2 more                                                                                                                                                                 
Exception in thread "main" java.lang.NoClassDefFoundError: Could not initialize class org.apache.hadoop.util.StringUtils                                                                              
        at org.apache.hadoop.util.ExitUtil.terminate(ExitUtil.java:170)                                                                                                         
        at org.apache.hadoop.hdfs.server.namenode.NameNode.main(NameNode.java:1621)
```
Selecting Java 8 is a workaround for this issue. Probably, updating to versions of all the components would be an elegant solution.
